### PR TITLE
Fix "catching" typo

### DIFF
--- a/ch07/declare_exceptions_catching.adb
+++ b/ch07/declare_exceptions_catching.adb
@@ -6,7 +6,7 @@ procedure Declare_Exceptions_Catching is
   Val1 : Integer := 45;
   Val2 : Integer := 0;
 begin
-  Ada.Text_IO.Put_Line("Getting started with cathing exceptions!");
+  Ada.Text_IO.Put_Line("Getting started with catching exceptions!");
 
   declare
   begin


### PR DESCRIPTION
Fix typo in chapter 07: change "cathing" to "catching" in the string printed to the console.