### PR TITLE
Fix British Pound currency string typo

### DIFF
--- a/ch12/custom_string_cast.adb
+++ b/ch12/custom_string_cast.adb
@@ -7,7 +7,7 @@ procedure Custom_String_Cast is
   subtype Currency_String is String(1 .. 3);
   US_Dollar : Currency_String         := "USD";
   Euro : Currency_String              := "EUR";
-  British_Pound : Currency_String     := "GPB";
+  British_Pound : Currency_String     := "GBP";
   Japan_Yen : Currency_String         := "JPY";
   Australian_Dollar : Currency_String := "AUD";
   HongKong_Dollar : Currency_String   := "HKD";


### PR DESCRIPTION
Fix British Pound currency string typo:
change "GPB" to the correct form "GBP".