### PR TITLE
Fix infinite loop issue on wrong input

### DIFF
--- a/ch12/limited_integer.adb
+++ b/ch12/limited_integer.adb
@@ -22,34 +22,34 @@ begin
     declare
     begin
       Menu_Input.Get(Selected);
+      case Selected is
+        when 1 =>
+          Ada.Text_IO.Put_Line("Your apples is ready!");
+          Ada.Text_IO.New_Line;
+        when 2 =>
+          Ada.Text_IO.Put_Line("Your pears is ready!");
+          Ada.Text_IO.New_Line;
+        when 3 =>
+          Ada.Text_IO.Put_Line("Your asparagus is ready!");
+          Ada.Text_IO.New_Line;
+        when 4 =>
+          Ada.Text_IO.Put_Line("Your cauliflower is ready!");
+          Ada.Text_IO.New_Line;
+        when 5 =>
+          Ada.Text_IO.Put_Line("Your granola bar is ready!");
+          Ada.Text_IO.New_Line;
+        when 6 =>
+          exit Main_Menu;
+        when others =>
+          Ada.Text_IO.Put_Line("ERROR: Unknown type!");
+          Ada.Text_IO.New_Line;
+      end case;
     exception
       when others =>
         Ada.Text_IO.New_Line;
         Ada.Text_IO.Put_Line("ERROR: Input incorrect, must be from 1 to 6.");
         Ada.Text_IO.New_Line(2);
+        Ada.Text_IO.Skip_Line;
     end Main_Menu_Input;
-
-    case Selected is
-      when 1 =>
-        Ada.Text_IO.Put_Line("Your apples is ready!");
-        Ada.Text_IO.New_Line;
-      when 2 =>
-        Ada.Text_IO.Put_Line("Your pears is ready!");
-        Ada.Text_IO.New_Line;
-      when 3 =>
-        Ada.Text_IO.Put_Line("Your asparagus is ready!");
-        Ada.Text_IO.New_Line;
-      when 4 =>
-        Ada.Text_IO.Put_Line("Your cauliflower is ready!");
-        Ada.Text_IO.New_Line;
-      when 5 =>
-        Ada.Text_IO.Put_Line("Your granola bar is ready!");
-        Ada.Text_IO.New_Line;
-      when 6 =>
-        exit Main_Menu;
-      when others =>
-        Ada.Text_IO.Put_Line("ERROR: Unknown type!");
-        Ada.Text_IO.New_Line;
-    end case;
   end loop Main_Menu;
 end Limited_Integer;


### PR DESCRIPTION
When user input is incorrect (letter or number outside of allowed
range, etc.), program no longer loops forever. This is due to call to
`Skip_Line` which "consumes" wrong input so it does not pollute input
buffer and user can enter a new entry. It was not the case before the fix.

`Case` block was moved inside the `Main_Menu_Input` block, so previous
correct choice is no longer printed on wrong input as it was the case
before the fix.